### PR TITLE
Add extensibility framework

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,0 +1,11 @@
+# Extensibility
+
+SAPro exposes several extension points for feature modules:
+
+- **Event listeners**: Use `sap.event_bus()` to subscribe to events using
+  `subscribe(event, listener)` and respond when events are emitted.
+- **Module registration**: Register new modules via `sap.register_module()` or
+  the convenience helpers `sap.register_tax_module()` and
+  `sap.register_payroll_module()`.
+- **Configuration hooks**: Provide `custom_fields` and `validation_rules`
+  through configuration and apply them with `sap.apply_hooks(config, bus)`.

--- a/sap/__init__.py
+++ b/sap/__init__.py
@@ -1,0 +1,18 @@
+"""Core package providing extension points for SAPro."""
+from .api import (
+    event_bus,
+    get_module,
+    register_module,
+    register_payroll_module,
+    register_tax_module,
+)
+from .hooks import apply_hooks
+
+__all__ = [
+    "event_bus",
+    "get_module",
+    "register_module",
+    "register_payroll_module",
+    "register_tax_module",
+    "apply_hooks",
+]

--- a/sap/api.py
+++ b/sap/api.py
@@ -1,0 +1,29 @@
+"""Internal APIs exposing core facilities for extension modules."""
+from typing import Any, Dict
+from .events import EventBus
+
+# Global event bus used across the application
+_event_bus = EventBus()
+# Registered modules by name
+_modules: Dict[str, Any] = {}
+
+def event_bus() -> EventBus:
+    """Return the application's :class:`EventBus`."""
+    return _event_bus
+
+def register_module(name: str, module: Any) -> None:
+    """Register a module under ``name`` and notify listeners."""
+    _modules[name] = module
+    _event_bus.emit("module_registered", name=name, module=module)
+
+def register_tax_module(module: Any) -> None:
+    """Convenience helper for registering a tax module."""
+    register_module("tax", module)
+
+def register_payroll_module(module: Any) -> None:
+    """Convenience helper for registering a payroll module."""
+    register_module("payroll", module)
+
+def get_module(name: str) -> Any:
+    """Return a previously registered module or ``None``."""
+    return _modules.get(name)

--- a/sap/events.py
+++ b/sap/events.py
@@ -1,0 +1,17 @@
+from collections import defaultdict
+from typing import Callable, Dict, List
+
+class EventBus:
+    """Simple publish/subscribe event system."""
+
+    def __init__(self) -> None:
+        self._listeners: Dict[str, List[Callable]] = defaultdict(list)
+
+    def subscribe(self, event: str, listener: Callable) -> None:
+        """Register ``listener`` to be called when ``event`` is emitted."""
+        self._listeners[event].append(listener)
+
+    def emit(self, event: str, **payload) -> None:
+        """Emit ``event`` and invoke all registered listeners with ``payload``."""
+        for listener in self._listeners.get(event, []):
+            listener(**payload)

--- a/sap/hooks.py
+++ b/sap/hooks.py
@@ -1,0 +1,19 @@
+"""Configuration-driven hooks for custom fields and validation rules."""
+from __future__ import annotations
+
+from typing import Any, Dict
+from .events import EventBus
+
+
+def apply_hooks(config: Dict[str, Any], bus: EventBus) -> None:
+    """Apply hooks defined in ``config`` using ``bus``.
+
+    The configuration may include:
+    ``custom_fields``: mapping of field name to default value
+    ``validation_rules``: mapping of rule name to callable accepting data
+    """
+    for field, default in config.get("custom_fields", {}).items():
+        bus.emit("register_custom_field", name=field, default=default)
+
+    for name, rule in config.get("validation_rules", {}).items():
+        bus.emit("register_validation_rule", name=name, rule=rule)


### PR DESCRIPTION
## Summary
- add simple EventBus for modules to publish and subscribe to events
- expose internal APIs for registering tax and payroll modules
- support configuration-driven hooks for custom fields and validation rules
- document available extension points

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab4bdf72e883209638f2c4cb0e207a