### PR TITLE
Add database setup scripts, Docker packaging, and maintenance docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.db
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Simple Docker image for SAP application
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+
+# Install dependencies if a requirements file is provided
+RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; fi
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # SAP
+
+This repository includes scripts and configuration to set up the sample SAP application.
+
+## Database setup
+
+Run `db/setup_db.sh` to create the SQLite database and load seed data.
+
+## Configuration templates
+
+Sample configuration files are available in the `config/` directory in YAML and TOML formats.
+
+## Packaging
+
+A `Dockerfile` is provided to build a containerized version of the application.
+
+## Maintenance
+
+Refer to `docs/UPGRADE.md` for upgrade steps and `docs/BACKUP.md` for backup procedures.

--- a/config/company_settings.toml
+++ b/config/company_settings.toml
@@ -1,0 +1,7 @@
+# Company settings template (TOML)
+[company]
+name = "Your Company Name"
+address = "123 Main St, City"
+
+[database]
+path = "sap.db"

--- a/config/company_settings.yaml
+++ b/config/company_settings.yaml
@@ -1,0 +1,6 @@
+# Company settings template (YAML)
+company:
+  name: "Your Company Name"
+  address: "123 Main St, City"
+database:
+  path: "sap.db"

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,6 @@
+-- Schema for SAP application
+CREATE TABLE IF NOT EXISTS employees (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    role TEXT NOT NULL
+);

--- a/db/seed_data.sql
+++ b/db/seed_data.sql
@@ -1,0 +1,3 @@
+-- Seed data for SAP application
+INSERT INTO employees (id, name, role) VALUES (1, 'Alice', 'Manager');
+INSERT INTO employees (id, name, role) VALUES (2, 'Bob', 'Developer');

--- a/db/setup_db.sh
+++ b/db/setup_db.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Initialize SQLite database and load seed data
+set -e
+DB_FILE=${1:-sap.db}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Initializing database: $DB_FILE"
+sqlite3 "$DB_FILE" < "$SCRIPT_DIR/schema.sql"
+sqlite3 "$DB_FILE" < "$SCRIPT_DIR/seed_data.sql"
+echo "Seed data loaded into $DB_FILE"

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,8 @@
+# Backup Procedure
+
+Regular backups protect against data loss. Recommended steps:
+
+1. Stop the application if it is running.
+2. Copy the database file `sap.db` to a secure location.
+3. Archive the `config/` directory to preserve settings.
+4. Store backups on off-site or cloud storage.

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,0 +1,9 @@
+# Upgrade Procedure
+
+Follow these steps to upgrade the SAP application:
+
+1. **Backup the database** before making changes.
+2. Pull the latest application code.
+3. Run `db/setup_db.sh` to apply new schema changes.
+4. Rebuild the Docker image or executable package.
+5. Redeploy the application and verify functionality.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+"""Entry point for the SAP application."""
+
+if __name__ == "__main__":
+    print("SAP application placeholder")


### PR DESCRIPTION
## Summary
- add SQLite schema, seed data, and setup script for database initialization
- provide YAML/TOML configuration templates
- include Dockerfile and placeholder main entrypoint
- document upgrade and backup procedures

## Testing
- `bash db/setup_db.sh test.db`
- `sqlite3 test.db 'SELECT * FROM employees;'`
- `python main.py`
- `docker --version` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures invalid)*
- `apt-get install -y docker.io` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68ab4bdb95108320ad6b3d2b1ccebb0e