### PR TITLE
Add Flask dashboard with help panel and wizards

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+# Help Index
+
+- [Invoice Entry](invoice.md)
+- [Stock Transfer](stock_transfer.md)

--- a/docs/invoice.md
+++ b/docs/invoice.md
@@ -1,0 +1,3 @@
+# Invoice Entry
+
+Use this wizard to record a new customer invoice.

--- a/docs/stock_transfer.md
+++ b/docs/stock_transfer.md
@@ -1,0 +1,3 @@
+# Stock Transfer
+
+Move inventory between locations with this wizard.

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -1,0 +1,74 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, session, abort
+
+app = Flask(__name__)
+app.secret_key = "dev"
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+DOCS_DIR = os.path.join(ROOT, "docs")
+
+def markdown_to_html(text: str) -> str:
+    """Minimal Markdown renderer supporting headings and paragraphs."""
+    lines = text.splitlines()
+    html_lines = []
+    for line in lines:
+        if line.startswith("### "):
+            html_lines.append(f"<h3>{line[4:]}</h3>")
+        elif line.startswith("## "):
+            html_lines.append(f"<h2>{line[3:]}</h2>")
+        elif line.startswith("# "):
+            html_lines.append(f"<h1>{line[2:]}</h1>")
+        else:
+            html_lines.append(f"<p>{line}</p>")
+    return "\n".join(html_lines)
+
+@app.route("/")
+def dashboard():
+    kpis = {"cash": 1000, "receivables": 500, "payables": 300, "stock": 150}
+    return render_template("dashboard.html", kpis=kpis)
+
+@app.route("/help/<doc>")
+def help_page(doc: str):
+    filename = doc if doc.endswith(".md") else f"{doc}.md"
+    path = os.path.join(DOCS_DIR, filename)
+    if not os.path.isfile(path):
+        abort(404)
+    with open(path, "r", encoding="utf-8") as f:
+        html = markdown_to_html(f.read())
+    return render_template("help.html", content=html)
+
+@app.route("/invoice", methods=["GET", "POST"])
+def invoice():
+    step = int(request.args.get("step", 1))
+    if request.method == "POST":
+        if step == 1:
+            session["invoice"] = {
+                "customer": request.form.get("customer", ""),
+                "amount": request.form.get("amount", ""),
+            }
+            return redirect(url_for("invoice", step=2))
+        else:
+            data = session.pop("invoice", {})
+            return render_template("invoice_done.html", data=data)
+    data = session.get("invoice", {})
+    return render_template(f"invoice_step{step}.html", data=data)
+
+@app.route("/stock-transfer", methods=["GET", "POST"])
+def stock_transfer():
+    step = int(request.args.get("step", 1))
+    if request.method == "POST":
+        if step == 1:
+            session["transfer"] = {
+                "item": request.form.get("item", ""),
+                "quantity": request.form.get("quantity", ""),
+                "from_location": request.form.get("from_location", ""),
+                "to_location": request.form.get("to_location", ""),
+            }
+            return redirect(url_for("stock_transfer", step=2))
+        else:
+            data = session.pop("transfer", {})
+            return render_template("stock_transfer_done.html", data=data)
+    data = session.get("transfer", {})
+    return render_template(f"stock_transfer_step{step}.html", data=data)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/presentation/templates/base.html
+++ b/presentation/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <title>SAP Dashboard</title>
+    <style>
+      body { font-family: Arial, sans-serif; display:flex; margin:0; }
+      nav { width:200px; padding:1em; background:#eee; }
+      .content { flex:1; padding:1em; }
+      .help-panel { width:300px; border-left:1px solid #ccc; }
+      iframe { width:100%; height:100%; border:0; }
+      nav a { display:block; margin-bottom:0.5em; }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <a href="{{ url_for('dashboard') }}">Dashboard</a>
+      <a href="{{ url_for('invoice') }}">Invoice Wizard</a>
+      <a href="{{ url_for('stock_transfer') }}">Stock Transfer Wizard</a>
+      <a href="{{ url_for('help_page', doc='index') }}" target="help">Help Index</a>
+    </nav>
+    <div class="content">
+      {% block content %}{% endblock %}
+    </div>
+    <div class="help-panel">
+      <iframe name="help" src="{{ url_for('help_page', doc='index') }}"></iframe>
+    </div>
+  </body>
+</html>

--- a/presentation/templates/dashboard.html
+++ b/presentation/templates/dashboard.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Dashboard</h1>
+<ul>
+  <li>Cash: {{ kpis.cash }}</li>
+  <li>Receivables: {{ kpis.receivables }}</li>
+  <li>Payables: {{ kpis.payables }}</li>
+  <li>Stock: {{ kpis.stock }}</li>
+</ul>
+{% endblock %}

--- a/presentation/templates/help.html
+++ b/presentation/templates/help.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Help</title>
+  </head>
+  <body>
+    {{ content|safe }}
+  </body>
+</html>

--- a/presentation/templates/invoice_done.html
+++ b/presentation/templates/invoice_done.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Invoice Saved</h1>
+<p>Invoice for {{ data.customer }} saved.</p>
+{% endblock %}

--- a/presentation/templates/invoice_step1.html
+++ b/presentation/templates/invoice_step1.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Invoice Entry - Step 1</h1>
+<form method="post">
+  Customer: <input name="customer"><br>
+  Amount: <input name="amount" type="number" step="0.01"><br>
+  <button type="submit">Next</button>
+</form>
+{% endblock %}

--- a/presentation/templates/invoice_step2.html
+++ b/presentation/templates/invoice_step2.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Invoice Entry - Step 2</h1>
+<p>Customer: {{ data.customer }}</p>
+<p>Amount: {{ data.amount }}</p>
+<form method="post">
+  <button type="submit">Confirm</button>
+</form>
+{% endblock %}

--- a/presentation/templates/stock_transfer_done.html
+++ b/presentation/templates/stock_transfer_done.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Transfer Completed</h1>
+<p>{{ data.quantity }} of {{ data.item }} moved from {{ data.from_location }} to {{ data.to_location }}.</p>
+{% endblock %}

--- a/presentation/templates/stock_transfer_step1.html
+++ b/presentation/templates/stock_transfer_step1.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Stock Transfer - Step 1</h1>
+<form method="post">
+  Item: <input name="item"><br>
+  Quantity: <input name="quantity" type="number" step="1"><br>
+  From: <input name="from_location"><br>
+  To: <input name="to_location"><br>
+  <button type="submit">Next</button>
+</form>
+{% endblock %}

--- a/presentation/templates/stock_transfer_step2.html
+++ b/presentation/templates/stock_transfer_step2.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Stock Transfer - Step 2</h1>
+<p>Item: {{ data.item }}</p>
+<p>Quantity: {{ data.quantity }}</p>
+<p>From: {{ data.from_location }}</p>
+<p>To: {{ data.to_location }}</p>
+<form method="post">
+  <button type="submit">Confirm</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build basic Flask app with dashboard showing cash, receivables, payables, and stock KPIs
- embed help panel that renders Markdown docs from local `docs/`
- add simple two-step form wizards for invoice entry and stock transfer workflows

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab4bd931e8832097a7432d15e02a2a