### PR TITLE
Add role-based security and audit logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/erp/__init__.py
+++ b/erp/__init__.py
@@ -1,0 +1,1 @@
+"""ERP package providing security and audit features."""

--- a/erp/audit.py
+++ b/erp/audit.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Audit logging facilities."""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import List, Tuple
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    """Represents a single immutable audit log entry."""
+
+    entity_id: int
+    entity_type: str
+    action: str
+    username: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class AuditLog:
+    """Immutable audit log table.
+
+    Entries can be appended but never modified or removed.
+    """
+
+    def __init__(self) -> None:
+        self._entries: List[AuditEntry] = []
+
+    def log_action(self, entity, user, action: str) -> None:
+        """Record an action performed by ``user`` on ``entity``."""
+        entry = AuditEntry(
+            entity_id=getattr(entity, "id", None),
+            entity_type=entity.__class__.__name__,
+            action=action,
+            username=user.username,
+        )
+        self._entries.append(entry)
+
+    def entries(self) -> Tuple[AuditEntry, ...]:
+        """Return audit entries as an immutable tuple."""
+        return tuple(self._entries)

--- a/erp/entities.py
+++ b/erp/entities.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Domain entities for the ERP system."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .audit import AuditLog
+from .security import Permission, User, has_permission
+
+
+@dataclass
+class Entity:
+    """Base entity storing audit metadata."""
+
+    id: int
+    created_by: str
+    posted_by: Optional[str] = None
+    approved_by: Optional[str] = None
+
+    def post(self, user: User, log: AuditLog) -> None:
+        """Post the entity if the user has the ``POST`` permission."""
+        if not has_permission(user, Permission.POST):
+            raise PermissionError("User lacks permission to post")
+        self.posted_by = user.username
+        log.log_action(self, user, "post")
+
+    def approve(self, user: User, log: AuditLog) -> None:
+        """Approve the entity if the user has the ``APPROVE`` permission."""
+        if not has_permission(user, Permission.APPROVE):
+            raise PermissionError("User lacks permission to approve")
+        self.approved_by = user.username
+        log.log_action(self, user, "approve")

--- a/erp/security.py
+++ b/erp/security.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Simple user, role and permission models for the ERP system."""
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import List
+
+
+class Permission(Enum):
+    """Supported permissions within the ERP system."""
+
+    POST = auto()
+    APPROVE = auto()
+
+
+@dataclass
+class Role:
+    """A role aggregates a set of permissions."""
+
+    name: str
+    permissions: List[Permission] = field(default_factory=list)
+
+
+@dataclass
+class User:
+    """Represents an authenticated user in the system."""
+
+    username: str
+    roles: List[Role] = field(default_factory=list)
+
+    def has_permission(self, permission: Permission) -> bool:
+        """Return ``True`` if the user is granted ``permission``."""
+        return any(permission in role.permissions for role in self.roles)
+
+
+def has_permission(user: User, permission: Permission) -> bool:
+    """Convenience helper to check for a permission on a user."""
+
+    return user.has_permission(permission)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,57 @@
+import pytest
+from dataclasses import FrozenInstanceError
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+from erp.audit import AuditLog
+from erp.entities import Entity
+from erp.security import Permission, Role, User
+
+
+def test_post_requires_permission():
+    poster_role = Role("poster", [Permission.POST])
+    poster = User("poster", [poster_role])
+    non_poster = User("nopost", [])
+
+    log = AuditLog()
+    doc = Entity(id=1, created_by="author")
+
+    doc.post(poster, log)
+    assert doc.posted_by == "poster"
+
+    with pytest.raises(PermissionError):
+        doc.post(non_poster, log)
+
+
+def test_approve_requires_permission():
+    approver_role = Role("approver", [Permission.APPROVE])
+    approver = User("approver", [approver_role])
+    non_approver = User("noapprove", [])
+
+    log = AuditLog()
+    doc = Entity(id=2, created_by="author")
+
+    doc.approve(approver, log)
+    assert doc.approved_by == "approver"
+
+    with pytest.raises(PermissionError):
+        doc.approve(non_approver, log)
+
+
+def test_audit_log_immutable():
+    role = Role("poster", [Permission.POST])
+    user = User("user", [role])
+    log = AuditLog()
+    doc = Entity(id=3, created_by="user")
+    doc.post(user, log)
+
+    entries = log.entries()
+    assert len(entries) == 1
+    entry = entries[0]
+
+    with pytest.raises(FrozenInstanceError):
+        entry.username = "hacker"
+
+    with pytest.raises(AttributeError):
+        entries.append(entry)


### PR DESCRIPTION
## Summary
- implement user, role, and permission models for ERP security
- enforce role-based posting and approval with audit metadata
- add immutable audit log with tests for permission enforcement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab4bd7a7908320acae787baec6ef67