### PR TITLE
Implement procurement lifecycle with GL postings and integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/erp/__init__.py
+++ b/erp/__init__.py
@@ -1,0 +1,17 @@
+from .models import (
+    GLPosting,
+    PurchaseRequisition,
+    PurchaseOrder,
+    GoodsReceipt,
+    VendorInvoice,
+    Inventory
+)
+
+__all__ = [
+    'GLPosting',
+    'PurchaseRequisition',
+    'PurchaseOrder',
+    'GoodsReceipt',
+    'VendorInvoice',
+    'Inventory'
+]

--- a/erp/models.py
+++ b/erp/models.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+
+@dataclass
+class GLPosting:
+    """Represents a general ledger posting."""
+    account: str
+    debit: float = 0.0
+    credit: float = 0.0
+    description: str = ""
+
+
+@dataclass
+class PurchaseRequisition:
+    """Request to purchase goods or services."""
+    id: str
+    item: str
+    quantity: int
+    gl_postings: List[GLPosting] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.gl_postings.append(
+            GLPosting(
+                account="Commitment",
+                description=f"Purchase requisition {self.id} created",
+            )
+        )
+
+
+@dataclass
+class PurchaseOrder:
+    """Order placed with a vendor to fulfill a requisition."""
+    id: str
+    requisition: PurchaseRequisition
+    vendor: str
+    price: float
+    gl_postings: List[GLPosting] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.gl_postings.append(
+            GLPosting(
+                account="PO Commitment",
+                description=f"Purchase order {self.id} created",
+            )
+        )
+
+
+@dataclass
+class Inventory:
+    """Simple in-memory inventory tracker."""
+    stock: Dict[str, int] = field(default_factory=dict)
+
+    def add(self, item: str, quantity: int) -> None:
+        self.stock[item] = self.stock.get(item, 0) + quantity
+
+
+@dataclass
+class GoodsReceipt:
+    """Receipt of goods against a purchase order."""
+    id: str
+    purchase_order: PurchaseOrder
+    quantity: int
+    inventory: Inventory
+    gl_postings: List[GLPosting] = field(default_factory=list)
+    vendor_invoice: VendorInvoice | None = None
+
+    def __post_init__(self) -> None:
+        # Update inventory
+        self.inventory.add(self.purchase_order.requisition.item, self.quantity)
+
+        amount = self.purchase_order.price * self.quantity
+        # GL posting for inventory increase
+        self.gl_postings.append(
+            GLPosting(
+                account="Inventory",
+                debit=amount,
+                description=f"Goods receipt {self.id}",
+            )
+        )
+        # GL posting for GR/IR liability
+        self.gl_postings.append(
+            GLPosting(
+                account="GR/IR",
+                credit=amount,
+                description=f"Goods receipt {self.id}",
+            )
+        )
+
+        # Automatically generate vendor invoice
+        self.vendor_invoice = VendorInvoice(goods_receipt=self, amount=amount)
+
+
+@dataclass
+class VendorInvoice:
+    """Invoice received from vendor after goods receipt."""
+    goods_receipt: GoodsReceipt
+    amount: float
+    gl_postings: List[GLPosting] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Clear GR/IR liability
+        self.gl_postings.append(
+            GLPosting(
+                account="GR/IR",
+                debit=self.amount,
+                description=f"Invoice for GR {self.goods_receipt.id}",
+            )
+        )
+        # Record accounts payable
+        self.gl_postings.append(
+            GLPosting(
+                account="Accounts Payable",
+                credit=self.amount,
+                description=f"Invoice for GR {self.goods_receipt.id}",
+            )
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,43 @@
+import unittest
+
+from erp import (
+    PurchaseRequisition,
+    PurchaseOrder,
+    GoodsReceipt,
+    Inventory,
+)
+
+
+class TestProcurementLifecycle(unittest.TestCase):
+    def test_full_lifecycle(self):
+        inventory = Inventory()
+
+        pr = PurchaseRequisition(id="PR1", item="Widget", quantity=10)
+        self.assertEqual(len(pr.gl_postings), 1)
+
+        po = PurchaseOrder(
+            id="PO1", requisition=pr, vendor="ACME", price=5.0
+        )
+        self.assertEqual(len(po.gl_postings), 1)
+
+        gr = GoodsReceipt(id="GR1", purchase_order=po, quantity=10, inventory=inventory)
+        self.assertEqual(inventory.stock.get("Widget"), 10)
+        self.assertIsNotNone(gr.vendor_invoice)
+        self.assertEqual(len(gr.gl_postings), 2)
+
+        invoice = gr.vendor_invoice
+        self.assertEqual(len(invoice.gl_postings), 2)
+
+        all_entries = (
+            pr.gl_postings
+            + po.gl_postings
+            + gr.gl_postings
+            + invoice.gl_postings
+        )
+        total_debits = sum(e.debit for e in all_entries)
+        total_credits = sum(e.credit for e in all_entries)
+        self.assertEqual(total_debits, total_credits)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add entities for purchase requisition, purchase order, goods receipt, vendor invoice and inventory
- generate GL postings at each procurement step
- link goods receipt to inventory updates and automatic vendor invoice creation
- cover full lifecycle with an integration test

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab4bd262d483208bc76f9738d5ad90